### PR TITLE
Add ExpiresAt to Session struct

### DIFF
--- a/integration_test/setup/docker-compose.yaml
+++ b/integration_test/setup/docker-compose.yaml
@@ -5,7 +5,7 @@ services:
     container_name: gotrue
     depends_on:
       - postgres
-    image: supabase/gotrue:v2.32.0
+    image: supabase/gotrue:v2.86.0
     restart: on-failure
     ports:
       - '9999:9999'
@@ -30,7 +30,7 @@ services:
     container_name: gotrue_autoconfirm
     depends_on:
       - postgres
-    image: supabase/gotrue:v2.32.0
+    image: supabase/gotrue:v2.86.0
     restart: on-failure
     ports:
       - '9998:9998'
@@ -62,7 +62,7 @@ services:
     container_name: gotrue_signup_disabled
     depends_on:
       - postgres
-    image: supabase/gotrue:v2.32.0
+    image: supabase/gotrue:v2.86.0
     restart: on-failure
     ports:
       - '9997:9997'

--- a/integration_test/signup_test.go
+++ b/integration_test/signup_test.go
@@ -66,7 +66,7 @@ func TestSignup(t *testing.T) {
 	assert.NotEmpty(session.RefreshToken)
 	assert.Equal("bearer", session.TokenType)
 	assert.Equal(3600, session.ExpiresIn)
-	assert.NotEmpty(session.ExpiresAt)
+	assert.InDelta(time.Now().Add(3600*time.Second).Unix(), session.ExpiresAt, float64(time.Second))
 
 	// Sign up with signups disabled
 	email = randomEmail()

--- a/integration_test/signup_test.go
+++ b/integration_test/signup_test.go
@@ -66,6 +66,7 @@ func TestSignup(t *testing.T) {
 	assert.NotEmpty(session.RefreshToken)
 	assert.Equal("bearer", session.TokenType)
 	assert.Equal(3600, session.ExpiresIn)
+	assert.NotEmpty(session.ExpiresAt)
 
 	// Sign up with signups disabled
 	email = randomEmail()

--- a/integration_test/token_test.go
+++ b/integration_test/token_test.go
@@ -36,6 +36,7 @@ func TestToken(t *testing.T) {
 	assert.NotEmpty(token.RefreshToken)
 	assert.Equal("bearer", token.TokenType)
 	assert.Equal(3600, token.ExpiresIn)
+	assert.NotEmpty(token.ExpiresAt)
 
 	// Signin with email convenience method
 	token, err = client.SignInWithEmailPassword(email, password)
@@ -45,6 +46,7 @@ func TestToken(t *testing.T) {
 	assert.NotEmpty(token.RefreshToken)
 	assert.Equal("bearer", token.TokenType)
 	assert.Equal(3600, token.ExpiresIn)
+	assert.NotEmpty(token.ExpiresAt)
 
 	// Test login with phone
 	phone := randomPhoneNumber()
@@ -67,6 +69,7 @@ func TestToken(t *testing.T) {
 	assert.NotEmpty(token.RefreshToken)
 	assert.Equal("bearer", token.TokenType)
 	assert.Equal(3600, token.ExpiresIn)
+	assert.NotEmpty(token.ExpiresAt)
 
 	// Signin with phone convenience method
 	token, err = client.SignInWithPhonePassword(phone, password)
@@ -76,6 +79,7 @@ func TestToken(t *testing.T) {
 	assert.NotEmpty(token.RefreshToken)
 	assert.Equal("bearer", token.TokenType)
 	assert.Equal(3600, token.ExpiresIn)
+	assert.NotEmpty(token.ExpiresAt)
 
 	// Incorrect password
 	_, err = client.Token(types.TokenRequest{
@@ -104,6 +108,7 @@ func TestToken(t *testing.T) {
 	assert.NotEmpty(token.RefreshToken)
 	assert.Equal("bearer", token.TokenType)
 	assert.Equal(3600, token.ExpiresIn)
+	assert.NotEmpty(token.ExpiresAt)
 
 	// Refresh token convenience method
 	token, err = client.RefreshToken(token.RefreshToken)
@@ -113,6 +118,7 @@ func TestToken(t *testing.T) {
 	assert.NotEmpty(token.RefreshToken)
 	assert.Equal("bearer", token.TokenType)
 	assert.Equal(3600, token.ExpiresIn)
+	assert.NotEmpty(token.ExpiresAt)
 
 	// Invalid input tests
 	tests := map[string]types.TokenRequest{

--- a/integration_test/token_test.go
+++ b/integration_test/token_test.go
@@ -2,6 +2,7 @@ package integration_test
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -36,7 +37,7 @@ func TestToken(t *testing.T) {
 	assert.NotEmpty(token.RefreshToken)
 	assert.Equal("bearer", token.TokenType)
 	assert.Equal(3600, token.ExpiresIn)
-	assert.NotEmpty(token.ExpiresAt)
+	assert.InDelta(time.Now().Add(3600*time.Second).Unix(), token.ExpiresAt, float64(time.Second))
 
 	// Signin with email convenience method
 	token, err = client.SignInWithEmailPassword(email, password)
@@ -46,7 +47,7 @@ func TestToken(t *testing.T) {
 	assert.NotEmpty(token.RefreshToken)
 	assert.Equal("bearer", token.TokenType)
 	assert.Equal(3600, token.ExpiresIn)
-	assert.NotEmpty(token.ExpiresAt)
+	assert.InDelta(time.Now().Add(3600*time.Second).Unix(), token.ExpiresAt, float64(time.Second))
 
 	// Test login with phone
 	phone := randomPhoneNumber()
@@ -69,7 +70,7 @@ func TestToken(t *testing.T) {
 	assert.NotEmpty(token.RefreshToken)
 	assert.Equal("bearer", token.TokenType)
 	assert.Equal(3600, token.ExpiresIn)
-	assert.NotEmpty(token.ExpiresAt)
+	assert.InDelta(time.Now().Add(3600*time.Second).Unix(), token.ExpiresAt, float64(time.Second))
 
 	// Signin with phone convenience method
 	token, err = client.SignInWithPhonePassword(phone, password)
@@ -79,7 +80,7 @@ func TestToken(t *testing.T) {
 	assert.NotEmpty(token.RefreshToken)
 	assert.Equal("bearer", token.TokenType)
 	assert.Equal(3600, token.ExpiresIn)
-	assert.NotEmpty(token.ExpiresAt)
+	assert.InDelta(time.Now().Add(3600*time.Second).Unix(), token.ExpiresAt, float64(time.Second))
 
 	// Incorrect password
 	_, err = client.Token(types.TokenRequest{
@@ -108,7 +109,7 @@ func TestToken(t *testing.T) {
 	assert.NotEmpty(token.RefreshToken)
 	assert.Equal("bearer", token.TokenType)
 	assert.Equal(3600, token.ExpiresIn)
-	assert.NotEmpty(token.ExpiresAt)
+	assert.InDelta(time.Now().Add(3600*time.Second).Unix(), token.ExpiresAt, float64(time.Second))
 
 	// Refresh token convenience method
 	token, err = client.RefreshToken(token.RefreshToken)
@@ -118,7 +119,7 @@ func TestToken(t *testing.T) {
 	assert.NotEmpty(token.RefreshToken)
 	assert.Equal("bearer", token.TokenType)
 	assert.Equal(3600, token.ExpiresIn)
-	assert.NotEmpty(token.ExpiresAt)
+	assert.InDelta(time.Now().Add(3600*time.Second).Unix(), token.ExpiresAt, float64(time.Second))
 
 	// Invalid input tests
 	tests := map[string]types.TokenRequest{

--- a/types/session.go
+++ b/types/session.go
@@ -5,5 +5,6 @@ type Session struct {
 	RefreshToken string `json:"refresh_token"`
 	TokenType    string `json:"token_type"`
 	ExpiresIn    int    `json:"expires_in"`
+	ExpiresAt    int64  `json:"expires_at"`
 	User         User   `json:"user"`
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Exposes the ExpiresAt field that was added in https://github.com/supabase/gotrue/pull/1183 The field is already there, this just makes it available through the client.

## What is the current behavior?

You cannot access the field through the client, even though it's exposed through the API.

## What is the new behavior?

You can access the field.

## Additional context

Was not able to run the integration tests locally, but running the code I was able to get the expected ExpiresAt. This field helped me manage the session/refreshing on the server side.