### PR TITLE
Add signup custom confirmation redirect url

### DIFF
--- a/endpoints/signup.go
+++ b/endpoints/signup.go
@@ -16,7 +16,7 @@ const signupPath = "/signup"
 
 // POST /signup
 //
-// Register a new user with an email and password.
+// Register a new user with an email, password and optional redirect url after email confirmation
 func (c *Client) Signup(req types.SignupRequest) (*types.SignupResponse, error) {
 	body, err := json.Marshal(req)
 	if err != nil {
@@ -26,6 +26,15 @@ func (c *Client) Signup(req types.SignupRequest) (*types.SignupResponse, error) 
 	r, err := c.newRequest(signupPath, http.MethodPost, bytes.NewBuffer(body))
 	if err != nil {
 		return nil, err
+	}
+
+	if req.ConfirmationRedirectUrl != "" {
+		q := r.URL.Query()
+		q.Add("redirect_to", req.ConfirmationRedirectUrl)
+		r.URL.RawQuery = q.Encode()
+
+		// Set up a client that will not follow the redirect.
+		c.client = noRedirClient(c.client)
 	}
 
 	resp, err := c.client.Do(r)

--- a/endpoints/signup.go
+++ b/endpoints/signup.go
@@ -16,7 +16,7 @@ const signupPath = "/signup"
 
 // POST /signup
 //
-// Register a new user with an email, password and optional redirect url after email confirmation
+// Register a new user with an email and password.
 func (c *Client) Signup(req types.SignupRequest) (*types.SignupResponse, error) {
 	body, err := json.Marshal(req)
 	if err != nil {

--- a/types/api.go
+++ b/types/api.go
@@ -425,11 +425,11 @@ type SettingsResponse struct {
 }
 
 type SignupRequest struct {
-	Email    string                 `json:"email,omitempty"`
-	Phone    string                 `json:"phone,omitempty"`
-	Password string                 `json:"password,omitempty"`
-	Data     map[string]interface{} `json:"data,omitempty"`
-
+	Email                   string                 `json:"email,omitempty"`
+	Phone                   string                 `json:"phone,omitempty"`
+	Password                string                 `json:"password,omitempty"`
+	Data                    map[string]interface{} `json:"data,omitempty"`
+	ConfirmationRedirectUrl string                 `json:"-"`
 	// Provide Captcha token if enabled.
 	SecurityEmbed
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature.

## What is the current behavior?

The current signup method does not allow to add a custom redirect url after user signup confirmation.

## What is the new behavior?

When the user clicks the confirm email link he gets in his email inbox, he can now be redirected to the custom url passed in this new feature. As long as this url is allowed in the Supabase Authentication Redirect URLs list (https://supabase.com/docs/guides/auth/redirect-urls).

## Additional context

The JS supabase library uses @supabase/auth-js, the implementation of the signUp method is here:
- https://github.com/supabase/auth-js/blob/e0dc51849680fa8f1900de786c4a7e77eab8760e/src/GoTrueClient.ts#L428
- https://github.com/supabase/auth-js/blob/e0dc51849680fa8f1900de786c4a7e77eab8760e/src/lib/fetch.ts#L147

As seen in the code, in order to support the signup custom redirect url the only thing you need to do is add a query param to the url like this: https://<projectRef>.supabase.co/auth/v1/signup?redirect_to=<customRedirectUrl>