### PR TITLE
Update GoTrue version under test and fix tests

### DIFF
--- a/endpoints/signup.go
+++ b/endpoints/signup.go
@@ -48,7 +48,7 @@ func (c *Client) Signup(req types.SignupRequest) (*types.SignupResponse, error) 
 	}
 
 	// To make the response easier to consume, if autoconfirm was enabled, the
-	// session user should be popuated. Copy that into the embedded user type
+	// session user should be populated. Copy that into the embedded user type
 	// so it's easier to access.
 	//
 	// i.e. we can access user fields like res.Email regardless of whether

--- a/integration_test/admingeneratelink_test.go
+++ b/integration_test/admingeneratelink_test.go
@@ -30,7 +30,7 @@ func TestAdminGenerateLink(t *testing.T) {
 	require.NoError(err)
 
 	assert.EqualValues(resp.VerificationType, "signup")
-	linkRegexp := regexp.MustCompile(`^http://localhost:9999/\?token=[a-zA-Z0-9_-]+&type=signup&redirect_to=http://localhost:3000$`)
+	linkRegexp := regexp.MustCompile(`^http://localhost:9999/verify\?token=[a-zA-Z0-9_-]+&type=signup&redirect_to=http://localhost:3000$`)
 	assert.Regexp(linkRegexp, resp.ActionLink)
 	assert.NotEmpty(resp.HashedToken)
 	assert.NotEmpty(resp.EmailOTP)
@@ -148,7 +148,7 @@ func TestAdminGenerateLink(t *testing.T) {
 	require.NoError(err)
 	assert.Equal("http://localhost:3000", resp.RedirectTo)
 	assert.EqualValues(resp.VerificationType, "email_change_current")
-	linkRegexp = regexp.MustCompile(`^http://localhost:9999/\?token=[a-zA-Z0-9_-]+&type=email_change&redirect_to=http://localhost:3000$`)
+	linkRegexp = regexp.MustCompile(`^http://localhost:9999/verify\?token=[a-zA-Z0-9_-]+&type=email_change&redirect_to=http://localhost:3000$`)
 	assert.Regexp(linkRegexp, resp.ActionLink)
 	assert.NotEmpty(resp.HashedToken)
 	assert.NotEmpty(resp.EmailOTP)

--- a/integration_test/setup/docker-compose.yaml
+++ b/integration_test/setup/docker-compose.yaml
@@ -5,10 +5,10 @@ services:
     container_name: gotrue
     depends_on:
       - postgres
-    image: supabase/gotrue:v2.86.0
+    image: supabase/gotrue:v2.157.0
     restart: on-failure
     ports:
-      - '9999:9999'
+      - "9999:9999"
     environment:
       GOTRUE_JWT_SECRET: "secret"
       GOTRUE_DB_DRIVER: "postgres"
@@ -30,10 +30,10 @@ services:
     container_name: gotrue_autoconfirm
     depends_on:
       - postgres
-    image: supabase/gotrue:v2.86.0
+    image: supabase/gotrue:v2.157.0
     restart: on-failure
     ports:
-      - '9998:9998'
+      - "9998:9998"
     environment:
       GOTRUE_JWT_SECRET: "secret"
       GOTRUE_DB_DRIVER: "postgres"
@@ -62,10 +62,10 @@ services:
     container_name: gotrue_signup_disabled
     depends_on:
       - postgres
-    image: supabase/gotrue:v2.86.0
+    image: supabase/gotrue:v2.157.0
     restart: on-failure
     ports:
-      - '9997:9997'
+      - "9997:9997"
     environment:
       GOTRUE_JWT_SECRET: "secret"
       GOTRUE_DB_DRIVER: "postgres"
@@ -90,7 +90,7 @@ services:
       dockerfile: Dockerfile.postgres.dev
     container_name: gotrue_postgres
     ports:
-      - '5432:5432'
+      - "5432:5432"
     environment:
       - POSTGRES_USER=postgres
       - POSTGRES_PASSWORD=root

--- a/integration_test/verify_test.go
+++ b/integration_test/verify_test.go
@@ -28,8 +28,8 @@ func TestVerify(t *testing.T) {
 	})
 	require.NoError(err)
 	assert.NotEmpty(vResp.URL)
-	assert.Equal("401", vResp.ErrorCode)
-	assert.Equal("unauthorized_client", vResp.Error)
+	assert.Equal("403", vResp.ErrorCode)
+	assert.Equal("access_denied", vResp.Error)
 
 	// Test Verify, invalid request
 	_, err = client.Verify(types.VerifyRequest{})


### PR DESCRIPTION
## What kind of change does this PR introduce?

Since the auth server has moved on a few versions, we can bump the version we use in integration tests and ensure our tests still pass. There are a handful of tiny non-breaking changes that broke assumptions in our tests - this PR fixes those so tests still pass.

## What is the new behavior?

Test updates only - no functional changes.